### PR TITLE
Update App.config

### DIFF
--- a/nri-perfmon/App.config
+++ b/nri-perfmon/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup>
+    <startup useLegacyV2RuntimeActivationPolicy="true">
       <supportedRuntime version="v4.0"/>
       <supportedRuntime version="v2.0.50727"/>
     </startup>


### PR DESCRIPTION
Newer versions of .NET Framework (e.g. 4.5.2) throw a System.IO.FileLoadException when trying to run nri-perfmon.exe. (See #35.) Adding flag as recommended by Microsoft (https://docs.microsoft.com/en-us/troubleshoot/developer/dotnet/framework/general/sgen-mixed-mode-assembly-built-v2-0-50727) to resolve this.