### PR TITLE
Fix issue  when counter fails

### DIFF
--- a/nri-perfmon/Plugin.cs
+++ b/nri-perfmon/Plugin.cs
@@ -482,9 +482,13 @@ namespace NewRelic
             {
                 var thisPC = PerfCounters[i];
                 thisPC.PopulatePerformanceCounters();
-                foreach (var pcKey in thisPC.PerformanceCounters.Keys)
+                foreach (var pcKey in thisPC.PerformanceCounters.Keys.ToList())
                 {
-                    var pcInPC = thisPC.PerformanceCounters[pcKey];
+                    if (!thisPC.PerformanceCounters.TryGetValue(pcKey, out var pcInPC))
+                    {
+                        continue;
+                    }
+
                     try
                     {
                         Log.WriteLog(string.Format("Collecting Perf Counter: {0}/{1}", pcInPC.CategoryName, pcInPC.CounterName), Log.LogLevel.VERBOSE);


### PR DESCRIPTION
The dictionary KEY in the affected loop are modified if accessing a counter fails, in the catch block:

`thisPC.PerformanceCounters.Remove(pcKey);`

This breaks containing loop interation key.