### PR TITLE
Fix setup making assumption that the NR service is ready to start

### DIFF
--- a/nri-perfmon/install/install-windows.ps1
+++ b/nri-perfmon/install/install-windows.ps1
@@ -71,10 +71,7 @@ Write-Host "-----------------------------------------`n"
 $serviceName = 'newrelic-infra'
 $nrServiceInfo = Get-Service -Name $serviceName
 
-if ($nrServiceInfo.Status -ne 'Running') {
-  Write-Host "New Relic Infrastructure not running currently, starting..."
-  Start-Service -Name $serviceName
-} else {
+if ($nrServiceInfo.Status -eq 'Running') {
   Stop-Service -Name $serviceName
   Start-Service -Name $serviceName
   Write-Host " Restart complete! "


### PR DESCRIPTION
The install script makes the assumption that the NRI service is ready to start. I am preparing some containers where NR license key is passed through ENV. During setup, NRI cannot start (and will fail) due to a lack of license key.

The culprit is this install script making the assumption that NRI should be started. Why won't it simply restart if it's started?